### PR TITLE
Bivariate Trait Plot Helper Function

### DIFF
--- a/R/qgsim.R
+++ b/R/qgsim.R
@@ -24,8 +24,8 @@ function(npops=2,mig=0,Ne=500,theta0=0,z0=0,h2=0.5,Gcor=0.2,omega11=1,omega22=1,
     ngens=100,tsd=0.02,tmn=0.01){
 
 	## always consider two traits
-	ntraits<-2    
-    
+	ntraits<-2
+
 	## construct the Gmatrix from the trait heritabilities, assumed to be the same for both traits,
 	## and genetic correlations
 	## this assumes the phenotypic variance is 1
@@ -220,4 +220,71 @@ qgsim_repl <- function(nreps=1, summaries=c(), npops=2,mig=0,Ne=500,theta0=0,z0=
   }
 
   return(sum_mat)
+}
+
+#' Generate a bivariate plot
+#'
+#' This function takes the output of qgsim and some specifiers and generates a bivariate qgsim_plot_bivar <- function(qgsim_res, pops, vars) {
+#' @param qgsim_res the results of a qgsim function call.
+#' @param populations either a single number indicating a population to plot, or a vector with two values indicating populations to plot against each other.
+#' @param vars either a single value or a vector of with two values indicating the z/theta values to plot against each other (can be z1, z2, theta1, or theta2).
+#' @param type same as for base R plot() function
+#' @param pch same as for base R plot() function
+#'
+#' @return the output of an r plot() function displaying the required bivariate plot
+qgsim_plot_bivar <- function(qgsim_res, populations, vars, type='p', pch=16) {
+  # if needed, replicate value in populations
+  if (length(populations) == 1) {populations <- rep(populations, 2)}
+
+  # check that requested populations are valid
+  npops <- length(qgsim_res$z)
+  if (length(populations) != 2) {
+    stop("Invalid length of argument 'populations'. Must be 1 or 2.")
+  } else if (max(populations) > npops || min(populations) <1) {
+    stop(paste("Invalid value in populations. Must be from 1:", npops, sep=""))
+  }
+
+  # if needed, replicate value in vars
+  if (length(vars) == 1) {vars <- rep(vars, 2)}
+
+  # check that requested vars are valid
+  valid_vars <- c('z1', 'z2', 'theta1', 'theta2')
+  invalid_vars <- setdiff(vars, valid_vars)
+  if (length(invalid_vars) > 0) {
+    stop(paste("Error: Invalid var/vars: ", paste(invalid_vars, collapse=", "), ". Must be in: ", paste(valid_vars, collapse = ", "), ".", sep=""))
+  } else if (length(vars) != 2) {
+    stop(paste("Error: invalid length for vars (", length(vars), "). Must be 1 or 2.", sep=""))
+  }
+
+  title_vals<-data.frame(
+    z1='Trait value 1',
+    z2='Trait value 2',
+    theta1='Optimal trait value 1',
+    theta2='Optimal trait value 2'
+    )
+
+  # generate x-axis title
+  x_title<-paste("Pop.", populations[1], "-", title_vals[[vars[1]]])
+  # generate y-axis title
+  y_title<-paste("Pop.", populations[2], "-", title_vals[[vars[2]]])
+
+  # extract x-values
+  x_vals <- switch(
+    vars[1],
+    "z1"=qgsim_res$z[[populations[1]]][,1],
+    "z2"=qgsim_res$z[[populations[1]]][,2],
+    "theta1"=qgsim_res$theta[[populations[1]]][,1],
+    "theta2"=qgsim_res$theta[[populations[1]]][,2]
+  )
+
+  # extract y-values
+  y_vals <- switch(
+    vars[2],
+    "z1"=qgsim_res$z[[populations[2]]][,1],
+    "z2"=qgsim_res$z[[populations[2]]][,2],
+    "theta1"=qgsim_res$theta[[populations[2]]][,1],
+    "theta2"=qgsim_res$theta[[populations[2]]][,2]
+  )
+
+  return(plot(x_vals, y_vals, xlab=x_title, ylab=y_title, type=type, pch=pch))
 }

--- a/R/qgsim.R
+++ b/R/qgsim.R
@@ -132,6 +132,32 @@ qgsim_repl <- function(nreps=1, summaries=c(), npops=2,mig=0,Ne=500,theta0=0,z0=
     res.z[[i]]<-res$z
     res.theta[[i]]<-res$theta
   }
+
+  # add in summaries
+
+  if ("mean_evol_rate" %in% summaries) {
+    # average rate of change in each trait across generations and populations
+
+    # sum the differences in each trait
+    for (rep_i in 1:nreps) {
+      delta_sum <- 0
+      z <- res.z[[rep_i]]
+      for (pop_i in 1:npops) {
+        pop <- z[[pop_i]]
+        for (gen_i in 2:ngens) {
+          # add trait 1 delta
+          delta_sum <- delta_sum + pop[gen_i, 1] - pop[gen_i-1, 1]
+          # add trait 2 delta
+          delta_sum <- delta_sum + pop[gen_i, 2] - pop[gen_i-1, 2]
+        }
+      }
+      # divide by (# traits) * (# generations) * (# populations)
+      mean_evol_rate <- delta_sum / (2 * ngens * npops)
+      sum_mat[rep_i,'mean_evol_rate'] <- mean_evol_rate
+    }
+  }
   
   return(sum_mat)
 }
+
+print(qgsim_repl(nreps=10, summaries = c('mean_evol_rate', 'mean_evol_lag')))

--- a/R/qgsim.R
+++ b/R/qgsim.R
@@ -199,7 +199,25 @@ qgsim_repl <- function(nreps=1, summaries=c(), npops=2,mig=0,Ne=500,theta0=0,z0=
     }
   }
 
+  if ("mean_popwise_corr" %in% summaries) {
+    for (rep_i in 1:nreps) {
+      corr_sum <- 0
+      ncors<-0
+      z <- res.z[[rep_i]]
+      for (pop1_i in 1:(npops-1)) {
+        for (pop2_i in (pop1_i+1):npops) {
+          pop1.z <- z[[pop1_i]]
+          pop2.z <- z[[pop2_i]]
+          corr_sum <- corr_sum + cor(pop1.z[,1], pop2.z[,1])
+          corr_sum <- corr_sum + cor(pop1.z[,2], pop2.z[,2])
+          ncors <- ncors + 2
+        }
+      }
+      # divide by number of correlations
+      mean_popwise_corr <- corr_sum / ncors
+      sum_mat[rep_i, 'mean_popwise_corr'] <- mean_popwise_corr
+    }
+  }
+
   return(sum_mat)
 }
-
-print(qgsim_repl(nreps=10, summaries = c('mean_evol_rate', 'mean_evol_lag', 'mean_traitwise_corr')))


### PR DESCRIPTION
# Summary of Changes
- Added a function which generates bivariate trait plots given a set of parameters and the output of a `qgsim()` simulation.
- The function `qgsim_plot_bivar()` takes as arguments `qgsim_res` (the result of a `qgsim()` run), `populations` (the population or populations to plot), `vars` (the traits/optimal trait values to plot), `type` (the type of plot required, defaults to 'p'), `pch` (the symbol used for points in the plot, defaults to 16).

# Notes
- **This pull request includes changes from the c3-replicate-wrapper branch. That pull request should be merged first!**
- Let me know if you'd like any additional functionality, etc.
- Documentation for this task is available on Card 4 on the Trello board.